### PR TITLE
Make sure the bib file is saved after importing a pdf from arxiv

### DIFF
--- a/org-ref-arxiv.el
+++ b/org-ref-arxiv.el
@@ -288,7 +288,8 @@ key."
       (when (file-exists-p (concat pdfdir key ".pdf"))
 	(bibtex-end-of-entry)
 	(backward-char)
-	(insert (format "  file = {%s}\n  " (concat pdfdir key ".pdf")))))))
+	(insert (format "  file = {%s}\n  " (concat pdfdir key ".pdf")))))
+    (save-buffer)))
 
 
 (provide 'org-ref-arxiv)


### PR DESCRIPTION
Added a `(save-buffer)` to `arxiv-get-pdf-add-bibtex-entry` to ensure the bib file is saved after the pdf is imported.